### PR TITLE
Only use one worker when running tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -v -s --tb=auto -n auto
+addopts = -v -s --tb=auto -n 1
 console_output_style = classic
 log_cli = True
 log_cli_level = INFO


### PR DESCRIPTION
Some failures are caused by using multiple workers with pytest. 