### PR TITLE
Updates to vLLM Example and Fine-Tuning Gemma Model

### DIFF
--- a/finetuning/gemma/upload.py
+++ b/finetuning/gemma/upload.py
@@ -1,0 +1,32 @@
+from beam import function, Volume, Image, env
+
+if env.is_remote():
+    from huggingface_hub import snapshot_download
+    from datasets import load_dataset
+
+VOLUME_PATH = "./gemma-ft"
+
+@function(
+    image=Image(
+        python_packages=[
+            "huggingface_hub",
+            "datasets"
+        ]
+    ),
+    memory="32Gi",
+    cpu=4,
+    secrets=["HF_TOKEN"],
+    volumes=[Volume(name="gemma-ft", mount_path=VOLUME_PATH)],
+)
+def upload():
+    snapshot_download(
+        repo_id="google/gemma-2b",
+        local_dir=f"{VOLUME_PATH}/weights"
+    )
+    
+    dataset = load_dataset("OpenAssistant/oasst1", split="train")
+    dataset.save_to_disk(f"{VOLUME_PATH}/data")
+    print("Files uploaded successfully")
+
+if __name__ == "__main__":
+    upload()

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -11,14 +11,14 @@ python inference.py
 
 ## Deploying OpenAI-compatible APIs
 
-Using `model.py`, we can deploy OpenAI-compatible APIs for three different LLMs. To do this, we use the `VLLM` wrapper class from the Beam SDK. Any command line argument that could be passed when calling `vllm serve` can be passed to the wrapper class via the `vllm_args` field. 
+Using `models.py`, we can deploy OpenAI-compatible APIs for three different LLMs. To do this, we use the `VLLM` wrapper class from the Beam SDK. Any command line argument that could be passed when calling `vllm serve` can be passed to the wrapper class via the `vllm_args` field. 
 
 The models can be deployed like this: 
 
 ```bash
-beam deploy model.py:phi_vision_instruct
-beam deploy model.py:yicoder_chat
-beam deploy model.py:mistral_instruct
+beam deploy models.py:phi_vision_instruct
+beam deploy models.py:yicoder_chat
+beam deploy models.py:mistral_instruct
 ```
 
 Each of these models supports different features. The `phi_vision_instruct` model supports multi-modal inference, the `yicoder_chat` model supports chat inference, and the `mistral_instruct` model supports chat inference with tool calling. 


### PR DESCRIPTION
This PR introduces the following updates and improvements:

1) Fix to vLLM Example README

The vLLM example's README.md previously instructed users to run:
```
beam deploy model.py:function
```
However, the file in the repository is actually named models.py.
Update: The README now reflects the correct filename:
```
beam deploy models.py:function
```

Addition of upload.py for Gemma Fine-Tuning
The fine-tuning example for the Gemma model has been improved with the addition of a new script `upload.py`.

Purpose: Automates downloading model weights and datasets directly to the Beam volume.

Advantages: Removes the need for users to first download files to their local machine and then upload them to Beam.
Simplifies the setup process for fine-tuning tasks.
